### PR TITLE
Fix footer positioning issue and update layout

### DIFF
--- a/illiana-app/src/app/app.component.html
+++ b/illiana-app/src/app/app.component.html
@@ -1,4 +1,8 @@
-<app-scroll-to-top></app-scroll-to-top>
-<app-navigation></app-navigation>
-<router-outlet></router-outlet>
-<app-footer></app-footer>
+<div id="layout">
+  <app-scroll-to-top></app-scroll-to-top>
+  <app-navigation></app-navigation>
+  <div id="content">
+    <router-outlet></router-outlet>
+  </div>
+  <app-footer></app-footer>
+</div>

--- a/illiana-app/src/app/app.component.scss
+++ b/illiana-app/src/app/app.component.scss
@@ -1,0 +1,14 @@
+// Added a layout to control the way
+// we want them to be displayed
+#layout {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 72px); // subtracted the height of the header(navigation)
+}
+
+// Added this flex grow to give the router outlet
+// a maximum of the view width
+#content {
+  flex-grow: 1;
+}
+

--- a/illiana-app/src/styles.scss
+++ b/illiana-app/src/styles.scss
@@ -168,7 +168,6 @@ h6 {
 
 #header {
   background: rgba(0, 0, 0, 0.9);
-  //   padding: 20px 0;
   height: $navigation-height;
   position: fixed;
   left: 0;


### PR DESCRIPTION
Hi @theaswanson,

I’ve fixed the issue where the footer was not staying at the bottom of the page when there was little to no content. The footer now correctly positions itself at the bottom of the page.

Here’s a screenshot demonstrating the fix with all content removed from the page, showing how the footer stays at the bottom as expected.

Let me know if any further adjustments are needed. Thanks!

![fixed footer issue](https://github.com/user-attachments/assets/18ef2fbe-2372-4b29-8aa4-81e11c553130)

